### PR TITLE
Capture the reason code and apply it to the payment

### DIFF
--- a/app/models/spree/paypal_express_checkout.rb
+++ b/app/models/spree/paypal_express_checkout.rb
@@ -1,4 +1,5 @@
 module Spree
   class PaypalExpressCheckout < ActiveRecord::Base
+    has_one :payment, as: :source
   end
 end


### PR DESCRIPTION
Intended to call this method on `Spree::Payment` in a failure scenario:

``` ruby
    def fail!(reason=nil)
      reason ||= cs_response_code
      return true if reason.blank?
      if changed?
        self.reason_code = reason
      else
        update_column(:reason_code, reason)
      end
    end
```
